### PR TITLE
Resolve incorrect peer dependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "gulp test"
   },
   "peerDependencies": {
-    "jquery": "^1.7.0"
+    "jquery": ">=1.7.0"
   },
   "devDependencies": {
     "gulp": "^3.9.0",


### PR DESCRIPTION
If you release a new version of this package after this PR, this will eliminate the `warning "atwho@1.5.3" has unmet peer dependency "jquery@^1.7.0".` message we get every time we do a `yarn install` in lotus.

jQuery is at 3.1.2 or something in Lotus.

You can verify the change should be working as intended here: http://jubianchi.github.io/semver-check/

Side-note — what is the `spm` section of this package.json? Notably, the peer dependency in that section uses the more lenient version check that would not have had this problem. 

@zendesk/orchid @zendesk/harrier 