### PR TITLE
[ZD-2703623] deleting space after @mention cursor jump

### DIFF
--- a/dist/js/jquery.atwho.js
+++ b/dist/js/jquery.atwho.js
@@ -831,13 +831,13 @@ EditableController = (function(superClass) {
     }
     suffix = (suffix = this.getOpt('suffix')) === "" ? suffix : suffix || "\u00A0";
     data = $li.data('item-data');
-    this.query.el.removeClass('atwho-query').addClass('atwho-inserted').html(content).attr('data-atwho-at-query', "" + data['atwho-at'] + this.query.text).attr('contenteditable', "false");
+    this.query.el.removeClass('atwho-query').addClass('atwho-inserted').html(content).attr('data-atwho-at-query', "" + data['atwho-at'] + this.query.text);
     if (range = this._getRange()) {
       if (this.query.el.length) {
         range.setEndAfter(this.query.el[0]);
       }
       range.collapse(false);
-      range.insertNode(suffixNode = this.app.document.createTextNode("" + suffix));
+      range.insertNode(suffixNode = this.app.document.createTextNode("\u200D" + suffix));
       this._setRange('after', suffixNode, range);
     }
     if (!this.$inputor.is(':focus')) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "homepage": "http://ichord.github.com/At.js",
   "license": "MIT",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/ichord/At.js"

--- a/src/editableController.coffee
+++ b/src/editableController.coffee
@@ -163,12 +163,11 @@ class EditableController extends Controller
       .addClass 'atwho-inserted'
       .html content
       .attr 'data-atwho-at-query', "" + data['atwho-at'] + @query.text
-      .attr 'contenteditable', "false"
     if range = @_getRange()
       if @query.el.length
         range.setEndAfter @query.el[0]
       range.collapse false
-      range.insertNode suffixNode = @app.document.createTextNode "" + suffix
+      range.insertNode suffixNode = @app.document.createTextNode "\u200D" + suffix
       @_setRange 'after', suffixNode, range
     @$inputor.focus() unless @$inputor.is ':focus'
     @$inputor.change()


### PR DESCRIPTION
<!-- Use GitHub’s “Reviewers” UI to request reviews. -->
<!-- For code-owner approval: Specify a 'full' or 'narrow' review. -->  
<!-- Until your PR is ready for review, include: :construction: **WIP** -->

## Context
This pull request fixes the cursor jumping problem when using `@mention` inside the content editor in `zendesk_console`. Whenever we use emoji and the mention functionality, the `At.j` library inserts a `span` with the attribute `contenteditable=false` while our content editor (see `.zendesk-editor--rich-text-comment`) has the attribute `contenteditable=true`. Right now, this kind of nesting is buggy and will cause weird behavior.

cc @zendesk/sustaining @zendesk/harrier 

Please see these PR's for reference:
Pull request that introduced the bug:
https://github.com/ichord/At.js/pull/423

Pull requests looking to reverse or have already been reversed:
https://github.com/ichord/At.js/issues/463
https://github.com/CenterForOpenScience/At.js/pull/3

## Description
[Zendesk Support Ticket 2703623](https://support.zendesk.com/agent/tickets/2703623)

Steps to reproduce:
1. Login a user with admin access.
2. Go to `/agent/tickets/<ticket-number>`
3. Try mentioning someone in either the public reply or internal note. 
4. After choosing a person to mention, press backspace and the cursor will jump to the end of the wysiwyg editor.

### Before
Google Chrome
![chrome-zd2703623-before](https://user-images.githubusercontent.com/3756584/42989319-042bd890-8c32-11e8-9f5a-701a6b40bb0f.gif)

Safari
![safari-zd2703623-before](https://user-images.githubusercontent.com/3756584/42989329-07e60dfc-8c32-11e8-9ef6-e1dc2a392bde.gif)

### After
Google Chrome
![chrome-zd2703623](https://user-images.githubusercontent.com/3756584/42989370-1c99a132-8c32-11e8-8442-ea8b73838f2f.gif)

Safari
![safari-zd2703623](https://user-images.githubusercontent.com/3756584/42989373-210478aa-8c32-11e8-9e30-c846fff22d1d.gif)

## Todo
- [ ] Create new release tag.
- [ ] Create PR in `zendesk_console` to update the `package.json`

## Risks
Low: the change just removes an attribute in html which the library doesn't use and adds \u200D as hack for the cursor positioning.