### PR TITLE
Change zwj to zws

### DIFF
--- a/dist/js/jquery.atwho.js
+++ b/dist/js/jquery.atwho.js
@@ -837,7 +837,7 @@ EditableController = (function(superClass) {
         range.setEndAfter(this.query.el[0]);
       }
       range.collapse(false);
-      range.insertNode(suffixNode = this.app.document.createTextNode("\u200D" + suffix));
+      range.insertNode(suffixNode = this.app.document.createTextNode("\u200B" + suffix));
       this._setRange('after', suffixNode, range);
     }
     if (!this.$inputor.is(':focus')) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "homepage": "http://ichord.github.com/At.js",
   "license": "MIT",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/ichord/At.js"

--- a/src/editableController.coffee
+++ b/src/editableController.coffee
@@ -167,7 +167,7 @@ class EditableController extends Controller
       if @query.el.length
         range.setEndAfter @query.el[0]
       range.collapse false
-      range.insertNode suffixNode = @app.document.createTextNode "\u200D" + suffix
+      range.insertNode suffixNode = @app.document.createTextNode "\u200B" + suffix
       @_setRange 'after', suffixNode, range
     @$inputor.focus() unless @$inputor.is ':focus'
     @$inputor.change()


### PR DESCRIPTION
#### Description

In `at.js` the zero width joiner unicode character (\u200D) is inserted after an at-mention is inserted into the rich text editor (for our use case, the at-mention is a condition placeholder). This zwj character causes problems with the cursor - additionally, the use case for the zwj character is very specific and in its current form does not do anything. By switching to a zero width space character we can preserve the spirit of the original implementation and fix the cursor issue.

This was tested on Google Chrome, Firefox, and Safari. The zwj character was added to `at.js` in this PR: https://github.com/zendesk/At.js/pull/7 - it's important to make sure we are not introducing any regressions with this change.

#### Before

![nov-27-2018 21-07-22](https://user-images.githubusercontent.com/4454158/49130461-dc484d00-f288-11e8-98c9-75bf7dee8a6a.gif)


#### After

![nov-27-2018 21-08-38](https://user-images.githubusercontent.com/4454158/49130462-deaaa700-f288-11e8-9920-62487163a94b.gif)


#### Reference

https://support.zendesk.com/agent/tickets/3945413